### PR TITLE
Fix append if file doesn't exist on s3

### DIFF
--- a/forge/drivers/s3.js
+++ b/forge/drivers/s3.js
@@ -90,7 +90,7 @@ module.exports = function (app) {
                     }
                 }
             } catch (err) {
-                if (err.Code === 'NoSuchKey') {
+                if (err.type === 'NotFound') {
                     // File not found so just write it
                     await this.save(this.teamId, this.projectId, path, data)
                 } else {


### PR DESCRIPTION
I was checking the wrong error field.

Might be a difference between real S3 and Minio. Fixing for S3 this time will check against Minio later.