### PR TITLE
Fix context not being cleaned when flow is removed

### DIFF
--- a/forge/context-driver/postgres.js
+++ b/forge/context-driver/postgres.js
@@ -73,7 +73,7 @@ module.exports = {
         const scopesResults = await pool.query(SCOPES, [projectId])
         const scopes = scopesResults.rows.map(s => s.scope)
         if (scopes.includes('global')) {
-            scopes.splice(scopes.indexOf('global'))
+            scopes.splice(scopes.indexOf('global'), 1)
         }
         if (scopes.length === 0) {
             return


### PR DESCRIPTION
* Ensures `activeIds` splices only the `"global"` context (postgres context driver issue)