### PR TITLE
Calculate quota in driver to ensure correct size

### DIFF
--- a/forge/context-driver/memory.js
+++ b/forge/context-driver/memory.js
@@ -38,15 +38,16 @@ module.exports = {
                     changeSize += getItemSize(element.value)
                 }
             })
-            const currentSize = await this.quota(projectId)
-            if (changeSize < 0) {
-                // if the change is negative then allow it to go through
-            } else if (currentSize + changeSize > quotaLimit) {
-                const err = new Error('Over Quota')
-                err.code = 'over_quota'
-                err.error = err.message
-                err.limit = quotaLimit
-                throw err
+            // only calculate the current size if we are going to need it
+            if (changeSize >= 0) {
+                const currentSize = await this.quota(projectId)
+                if (currentSize + changeSize > quotaLimit) {
+                    const err = new Error('Over Quota')
+                    err.code = 'over_quota'
+                    err.error = err.message
+                    err.limit = quotaLimit
+                    throw err
+                }
             }
         }
         input.forEach(element => {

--- a/forge/context-driver/memory.js
+++ b/forge/context-driver/memory.js
@@ -28,18 +28,20 @@ module.exports = {
                 const currentItem = projectStore ? getObjectProperty(projectStore, path) : undefined
                 if (currentItem === undefined && element.value !== undefined) {
                     // this is an addition
-                    changeSize += getItemSize(element)
+                    changeSize += getItemSize(element.value)
                 } else if (currentItem !== undefined && element.value === undefined) {
                     // this is an deletion
                     changeSize -= getItemSize(currentItem)
                 } else {
                     // this is an update
                     changeSize -= getItemSize(currentItem)
-                    changeSize += getItemSize(element)
+                    changeSize += getItemSize(element.value)
                 }
             })
             const currentSize = await this.quota(projectId)
-            if (currentSize + changeSize > quotaLimit) {
+            if (changeSize < 0) {
+                // if the change is negative then allow it to go through
+            } else if (currentSize + changeSize > quotaLimit) {
                 const err = new Error('Over Quota')
                 err.code = 'over_quota'
                 err.error = err.message

--- a/forge/context-driver/memory.js
+++ b/forge/context-driver/memory.js
@@ -1,15 +1,55 @@
+const { getObjectProperty, getItemSize } = require('./quotaTools')
 const util = require('@node-red/util').util
 
 const store = {}
-
+let app
 module.exports = {
-    init: function (app) {
+    init: function (_app) {
+        app = _app
         app.log.info('FlowForge File Server using Memory Context')
     },
     set: async function (projectId, scope, input) {
+        if (!store[projectId]) {
+            store[projectId] = {}
+        }
+        const projectStore = store[projectId]
+        const quotaLimit = app.config?.context?.quota || 0
+        // if quota is set, check if we are over quota or will be after this update
+        if (quotaLimit > 0) {
+            // Difficulties implementing this correctly
+            // - The final size of data can only be determined after the data is stored.
+            //   This is due to the fact that some keys may be deleted and some may be added
+            //   and the size of the data is not the same as the size of the keys.
+            // This implementation is not ideal, but it is a good approximation and will
+            //   prevent the possibility of runaway storage usage.
+            let changeSize = 0
+            input.forEach(element => {
+                const path = scope + '.' + element.key
+                const currentItem = projectStore ? getObjectProperty(projectStore, path) : undefined
+                if (currentItem === undefined && element.value !== undefined) {
+                    // this is an addition
+                    changeSize += getItemSize(element)
+                } else if (currentItem !== undefined && element.value === undefined) {
+                    // this is an deletion
+                    changeSize -= getItemSize(currentItem)
+                } else {
+                    // this is an update
+                    changeSize -= getItemSize(currentItem)
+                    changeSize += getItemSize(element)
+                }
+            })
+            const currentSize = await this.quota(projectId)
+            if (currentSize + changeSize > quotaLimit) {
+                const err = new Error('Over Quota')
+                err.code = 'over_quota'
+                err.error = err.message
+                err.limit = quotaLimit
+                throw err
+            }
+        }
         input.forEach(element => {
-            const fullPath = projectId + '.' + scope + '.' + element.key
-            util.setObjectProperty(store, fullPath, element.value)
+            const path = scope + '.' + element.key
+            util.setObjectProperty(projectStore, path, element.value)
         })
     },
     get: async function (projectId, scope, keys) {
@@ -65,5 +105,9 @@ module.exports = {
                 }
             }
         }
+    },
+    quota: async function (projectId) {
+        const projectStore = store[projectId]
+        return getItemSize(projectStore)
     }
 }

--- a/forge/context-driver/quotaTools.js
+++ b/forge/context-driver/quotaTools.js
@@ -1,0 +1,53 @@
+const util = require('@node-red/util').util
+
+/**
+ * Gets a property of an object.
+ *
+ * Given the object:
+ *
+ *     {
+ *       "pet": {
+ *           "type": "cat"
+ *       }
+ *     }
+ *
+ * - `pet.type` will return `"cat"`.
+ * - `pet.name` will return `undefined`
+ * - `pet.properties.this.that` will return `undefined`
+ * - `car` will return `undefined`
+ * - `car.type`  will return `undefined`
+ *
+ * @param  {Object} object - the object
+ * @param  {String} path - the property expression
+ * @return {any} the object property, or undefined if it does not exist
+ */
+function getObjectProperty (object, path) {
+    const msgPropParts = util.normalisePropertyExpression(path, object)
+    return msgPropParts.reduce((obj, key) =>
+        (obj && obj[key] !== 'undefined') ? obj[key] : undefined, object)
+}
+
+/**
+ * Gets the size of an object.
+ * @param  {Object} blob - the object
+ * @return {Number} the size of the object
+ */
+function getItemSize (blob) {
+    let size = 0
+    if (blob === null) {
+        return 1
+    } else if (typeof blob === 'undefined') {
+        return 0
+    }
+    if (typeof blob === 'string') {
+        size = blob.length
+    } else if (typeof blob === 'object') {
+        size = size + JSON.stringify(blob).length
+    }
+    return size
+}
+
+module.exports = {
+    getObjectProperty,
+    getItemSize
+}

--- a/forge/context-driver/quotaTools.js
+++ b/forge/context-driver/quotaTools.js
@@ -41,7 +41,7 @@ function getItemSize (blob) {
     }
     if (typeof blob === 'string') {
         size = blob.length
-    } else if (typeof blob === 'object') {
+    } else {
         size = size + JSON.stringify(blob).length
     }
     return size

--- a/forge/context-driver/sequelize.js
+++ b/forge/context-driver/sequelize.js
@@ -92,15 +92,16 @@ module.exports = {
                         changeSize += getItemSize(element.value)
                     }
                 }
-                const currentSize = await this.quota(projectId)
-                if (changeSize < 0) {
-                    // if the change is negative then allow it to go through
-                } else if (currentSize + changeSize > quotaLimit) {
-                    const err = new Error('Over Quota')
-                    err.code = 'over_quota'
-                    err.error = err.message
-                    err.limit = quotaLimit
-                    throw err
+                // only calculate the current size if we are going to need it
+                if (changeSize >= 0) {
+                    const currentSize = await this.quota(projectId)
+                    if (currentSize + changeSize > quotaLimit) {
+                        const err = new Error('Over Quota')
+                        err.code = 'over_quota'
+                        err.error = err.message
+                        err.limit = quotaLimit
+                        throw err
+                    }
                 }
             }
             let existing = await this.Context.findOne({

--- a/forge/context-driver/sequelize.js
+++ b/forge/context-driver/sequelize.js
@@ -82,18 +82,20 @@ module.exports = {
                     const currentItem = row ? getObjectProperty(row.values, element.key) : undefined
                     if (currentItem === undefined && element.value !== undefined) {
                         // this is an addition
-                        changeSize += getItemSize(element)
+                        changeSize += getItemSize(element.value)
                     } else if (currentItem !== undefined && element.value === undefined) {
                         // this is an deletion
                         changeSize -= getItemSize(currentItem)
                     } else {
                         // this is an update
                         changeSize -= getItemSize(currentItem)
-                        changeSize += getItemSize(element)
+                        changeSize += getItemSize(element.value)
                     }
                 }
                 const currentSize = await this.quota(projectId)
-                if (currentSize + changeSize > quotaLimit) {
+                if (changeSize < 0) {
+                    // if the change is negative then allow it to go through
+                } else if (currentSize + changeSize > quotaLimit) {
                     const err = new Error('Over Quota')
                     err.code = 'over_quota'
                     err.error = err.message

--- a/forge/context-driver/sequelize.js
+++ b/forge/context-driver/sequelize.js
@@ -1,11 +1,13 @@
 const { Sequelize, DataTypes } = require('sequelize')
+const { getObjectProperty, getItemSize } = require('./quotaTools')
 const util = require('@node-red/util').util
 const path = require('path')
 
-let sequelize
+let sequelize, app
 
 module.exports = {
-    init: async function (app) {
+    init: async function (_app) {
+        app = _app
         const dbOptions = {
             dialect: app.config.context.options.type || 'sqlite',
             logging: !!app.config.context.options.logging
@@ -58,6 +60,47 @@ module.exports = {
             type: Sequelize.Transaction.TYPES.IMMEDIATE
         },
         async (t) => {
+            const quotaLimit = app.config?.context?.quota || 0
+            // if quota is set, check if we are over quota or will be after this update
+            if (quotaLimit > 0) {
+                // Difficulties implementing this correctly
+                // - The final size of data can only be determined after the data is stored.
+                //   This is due to the fact that some keys may be deleted and some may be added
+                //   and the size of the data is not the same as the size of the keys.
+                // This implementation is not ideal, but it is a good approximation and will
+                //   prevent the possibility of runaway storage usage.
+                let changeSize = 0
+                const { path } = parseScope(scope)
+                const row = await this.Context.findOne({
+                    attributes: ['values'],
+                    where: {
+                        project: projectId,
+                        scope: path
+                    }
+                })
+                for (const element of input) {
+                    const currentItem = row ? getObjectProperty(row.values, element.key) : undefined
+                    if (currentItem === undefined && element.value !== undefined) {
+                        // this is an addition
+                        changeSize += getItemSize(element)
+                    } else if (currentItem !== undefined && element.value === undefined) {
+                        // this is an deletion
+                        changeSize -= getItemSize(currentItem)
+                    } else {
+                        // this is an update
+                        changeSize -= getItemSize(currentItem)
+                        changeSize += getItemSize(element)
+                    }
+                }
+                const currentSize = await this.quota(projectId)
+                if (currentSize + changeSize > quotaLimit) {
+                    const err = new Error('Over Quota')
+                    err.code = 'over_quota'
+                    err.error = err.message
+                    err.limit = quotaLimit
+                    throw err
+                }
+            }
             let existing = await this.Context.findOne({
                 where: {
                     project: projectId,

--- a/test/unit/setup.js
+++ b/test/unit/setup.js
@@ -64,6 +64,7 @@ async function setupApp (config = {}) {
         },
         context: {
             type: config.contextDriver || 'memory',
+            quota: config.contextQuota || 100000, // default context quota is 100KB
             options: config.contextDriverOptions
         }
     }


### PR DESCRIPTION
Fix up quota calculations

Key points...
* adds an alternative `getObjectProperty` function in `quotaTools.js`
  * This was necessary as the node-red utils version throws when an element doesnt exist
  * For us to calculate the +/- changes we need the `getObjectProperty` function to return `undefined`
* moves the quota checks into the driver
* caters for multiple SETs by pre-calculating the difference and throwing if > quota
* add quota tests.

New Tests...
```
  Context API
    memory driver
      Set API
        Set flow context value
          ✔ Should fail if quota is exceeded
      Quota tests
        ✔ Should fail if quota is exceeded across scopes (345ms)
        ✔ Should allow update/deletion/addition without exceeding quota (216ms)
```