### PR TITLE
Move to SQLite from Memory context

### DIFF
--- a/etc/flowforge-storage.yml
+++ b/etc/flowforge-storage.yml
@@ -16,4 +16,7 @@ driver:
   #   forcePathStyle: true
   #   region: eu-west-1
 context:
-  type: memory
+  type: sequelize
+  options:
+    type: sqlite
+    storage: ff-context.db


### PR DESCRIPTION
fixes #67 
## Description

<!-- Describe your changes in detail -->
When removing the memory context store the default config file was not updated.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#67 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

